### PR TITLE
Attempt to make ncrystal conda pkg depend on compiler but not python.

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   folder: src
 
 build:
-  number: 1
+  number: 2
   skip: true  # [win]
   skip: true  # [py<36]
 
@@ -18,10 +18,10 @@ requirements:
   build:
     - cmake
     - make  # [not win]
+    - python
     - {{ compiler('cxx') }}
   host:
-    - python
-    - pip
+    - {{ compiler('cxx') }}
   run:
     - python
     - numpy


### PR DESCRIPTION
I noticed that ncrystal conda pkgs are built for all python versions, but the ncrystal binaries does not have a compile-time dependency on python (except that a python script is used to convert some text files to .cxx files but that should give the same output for all python versions).

This PR is an attempt to fix this.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
